### PR TITLE
Add configurable flash sizes and counts

### DIFF
--- a/SPDump.c
+++ b/SPDump.c
@@ -2,104 +2,90 @@
 //  sudo /opt/toolchains/dc/bin/dc-tool-ser -t /dev/ttyUSB0 -b 781250 -c . -x /mnt/SSD1TB/src/SPDump/SPDump.elf 
 
 #include <kos.h>
+#include <stdlib.h>
 
-#define RAM_DEST 0x8C400000
+// Modify the following lines to match the flash configuration
+// used on your SystemSP board:
 
-void getROMData (uint16_t* pdst, int len){
- uint16_t* psrc = (uint16_t*)0xA1000000;
+#define FLASH_SIZE_MBIT     512  // 512 MBit flash chip
+// #define FLASH_SIZE_MBIT     128  // 128 MBit flash chip
 
- while (len--){
-    *pdst++ = *(uint16_t*)psrc;
-    psrc++;
+#define FLASH_CHIP_COUNT    2    // Only 62 & 63 are populated
+// #define FLASH_CHIP_COUNT    8    // All 8 flash chips are populated
+
+// End of configuration
+
+
+#define BANK_SIZE           0x10000
+#define FLASH_SIZE_BYTE     (FLASH_SIZE_MBIT * 1024 * 1024 / 8)
+#define BANKS_PER_FLASH     (FLASH_SIZE_BYTE / BANK_SIZE)
+#define BANKS_PER_XFER      32
+
+static const char * CHIP_NAMES[8] = { "62", "63", "64", "65", "66s", "67s", "68s", "69s" };
+static volatile uint32_t* FLASH_BASE = (volatile uint32_t*)0xA1000000;
+static volatile uint32_t* FLASH_BANK_REG = (volatile uint32_t*)0xA1010000;
+__attribute__((aligned(4)))
+static uint8_t DATA_BUFFER[(BANK_SIZE * BANKS_PER_XFER)] = {};
+
+const char * getChipName (int chipIndex){
+ if (chipIndex > 8){
+    printf("invalid chip index %d\n", chipIndex);
+    exit(-1);
+ }
+ return CHIP_NAMES[chipIndex];
+}
+
+void setBank (uint32_t bankNr){
+ *FLASH_BANK_REG = bankNr;
+}
+
+void copySingleBank (uint8_t* pdst, int bankNum, int len){    
+ setBank(bankNum);
+ memcpy(pdst, (void*) FLASH_BASE, len);
+}
+
+void copyMultiBanks(uint8_t* pdst, int startBank, int bankCount){
+ for (int i = 0; i < bankCount; i++){
+    copySingleBank(pdst, startBank + i, BANK_SIZE);
+    pdst += (BANK_SIZE);
  }
 }
 
-
-void setBank (uint32_t bankNr){
- volatile uint32_t* spbankreg = (volatile uint32_t*)0xA1010000;
-
- *spbankreg = bankNr;
-}
-
-
-int curBank = 0;
-
-void dumpOneChip (char* filename, uint32_t offset, uint32_t bytesInOneChip){
+void dumpOneChip (const char* filename, int chipIndex){
+ const int bankOffset = chipIndex * BANKS_PER_FLASH;
  FILE *fout;
- int numBanks = bytesInOneChip / 0x10000;
- uint8_t* pdst = (uint8_t*)RAM_DEST;
-
+ 
  printf("file %s:\n", filename);
  fout = fopen (filename, "wb");
  if (!fout){
     printf("unable to open file %s...\n", filename);
     return;
- } else {
-    printf("writing output file...\n");
  }
 
- printf("fetching ROM data...\n");
- for (int i=0; i < numBanks; i++){
-    getROMData ((uint16_t*)pdst, 0x10000 /2);
-    curBank++;
-    setBank(curBank);
-    pdst += 0x10000;
+ printf("fetching ROM data for ic%s...\n", getChipName(chipIndex));
+ for (int curBank=0; curBank < BANKS_PER_FLASH; curBank += BANKS_PER_XFER) {
+    printf("reading bank %d of %d...", curBank, BANKS_PER_FLASH);
+    fflush(stdout);
+    copyMultiBanks(DATA_BUFFER, bankOffset + curBank, BANKS_PER_XFER);
+    fwrite (DATA_BUFFER, BANK_SIZE * BANKS_PER_XFER, 1, fout);
+    printf("done.\n");
  }
  
- fwrite ((void*)RAM_DEST, bytesInOneChip, 1, fout);
-
  fclose (fout);
  printf("file %s closed.\n", filename);
 }
 
-void dumpFlashRomData (int mbitsize, int numChips){
- int bytesInOneChip = (mbitsize / 8) * 1024 * 1024;
- char* filename;
- uint32_t offset = 0;
-
- for (int i = 0; i < numChips; i++){
-    switch (i){
-        case 0:
-            filename = "/pc/ic62";
-            break;
-        case 1:
-            filename = "/pc/ic63";
-            break;
-        case 2:
-            filename = "/pc/ic64";
-            break;
-        case 3:
-            filename = "/pc/ic65";
-            break;
-        case 4:
-            filename = "/pc/ic66s";
-            break;
-        case 5:
-            filename = "/pc/ic67s";
-            break;
-        case 6:
-            filename = "/pc/ic68s";
-            break;
-        case 7:
-            filename = "/pc/ic69s";
-            break;
-        default:
-            return;
-	}
-    
-    dumpOneChip (filename, offset, bytesInOneChip);
-    offset += bytesInOneChip;
+void dumpFlashRomData (){
+ for (int i = 0; i < FLASH_CHIP_COUNT; i++){
+    char filename[32];
+    sprintf(filename, "/pc/ic%s", getChipName(i));
+    dumpOneChip (filename, i);
  }
-
 }
 
-int main(int argc, char *argv[]) {
- printf("starting SPDump...\n");
-
- //WARNING: this program copies the flash data into RAM, so it doesn't work yet with 512Mbits chips (easy fix needs to be implemented still)
- dumpFlashRomData (128, 3);//bingogals
- //dumpFlashRomData (128, 8);//bingogal
-
+int main(int argc, char *argv[]){
+ printf("\nstarting SPDump...\n");
+ dumpFlashRomData();
  printf("ending SPDump...\n");
  
  return (0);


### PR DESCRIPTION
- Changed dumping procedure to copy banks to memory and then flush to disk instead of loading each chip fully into RAM
- Added output to show current bank progress
- Switched flash to RAM copy to use memcpy
- Use static buffer instead of raw memory location